### PR TITLE
Fix/merge url client options

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -62,9 +62,9 @@ export interface BunSqlClientOptions {
 	// Pool
 	/** Maximum number of connections in the pool @default 10 */
 	max?: number;
-	/** Maximum time in seconds to wait for connection to become available @default 0 */
+	/** Maximum idle time in seconds before a connection is closed @default 0 (no limit) */
 	idleTimeout?: number;
-	/** Maximum lifetime in seconds of a connection @default 0 */
+	/** Maximum lifetime in seconds of a connection before it's closed and recreated @default 0 (no limit) */
 	maxLifetime?: number;
 	/** Maximum time in seconds to wait when establishing a connection @default 30 */
 	connectionTimeout?: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
-export type { BunPostgresDialectConfig } from "./config";
+export type { BunPostgresDialectConfig, BunSqlClientOptions } from "./config";
 export { BunPostgresDialect } from "./dialect";
+export { resolveSqlConstructorArgs, type SqlConstructorArgs } from "./driver";


### PR DESCRIPTION
This pull request enhances the Bun SQL client configuration and connection logic to provide more flexibility and clarity for users working with PostgreSQL connections. The main improvements are in the configuration interface and how connection options are merged when both a URL and additional client options are specified.

Configuration enhancements:

* Added detailed documentation comments to the `BunSqlClientOptions` interface, clarifying default values and option purposes, such as connection pooling, timeouts, prepared statements, and TLS/SSL support.

Connection logic improvements:

* Updated the `BunPostgresDriver` class to merge the connection `url` with additional `clientOptions` when both are provided, ensuring all relevant settings are applied during SQL client instantiation.### Summary

Describe the change and why it’s needed.

### Checklist

- [ ] Linted (`bun run lint`)
- [ ] Typechecked (`bun run typecheck`)
- [ ] Tests pass (`bun test`)
- [ ] Added/updated tests (if behavior changed)
