### PR TITLE
Feat/transaction settings

### DIFF
--- a/test/bun-postgres-driver.unit.test.ts
+++ b/test/bun-postgres-driver.unit.test.ts
@@ -186,6 +186,44 @@ describe("BunPostgresDriver (unit)", () => {
 		await driver.releaseConnection(conn);
 	});
 
+	test("transaction with only isolation level", async () => {
+		const { client, unsafe } = createStubClient();
+		const driver = new BunPostgresDriver({ client: client as unknown as SQL });
+		await driver.init();
+		const conn = await driver.acquireConnection();
+
+		await driver.beginTransaction(conn, {
+			isolationLevel: "serializable",
+		});
+
+		const calledSql = unsafe.mock.calls.map(
+			(c) => (c as unknown as [string])[0],
+		);
+		expect(calledSql).toEqual([
+			"start transaction isolation level serializable",
+		]);
+
+		await driver.releaseConnection(conn);
+	});
+
+	test("transaction with only access mode", async () => {
+		const { client, unsafe } = createStubClient();
+		const driver = new BunPostgresDriver({ client: client as unknown as SQL });
+		await driver.init();
+		const conn = await driver.acquireConnection();
+
+		await driver.beginTransaction(conn, {
+			accessMode: "read only",
+		});
+
+		const calledSql = unsafe.mock.calls.map(
+			(c) => (c as unknown as [string])[0],
+		);
+		expect(calledSql).toEqual(["start transaction read only"]);
+
+		await driver.releaseConnection(conn);
+	});
+
 	test("releaseConnection and destroy close resources", async () => {
 		const { client, release, close } = createStubClient();
 		const driver = new BunPostgresDriver({ client: client as unknown as SQL });


### PR DESCRIPTION
This pull request updates the `BunPostgresDriver` to support advanced transaction settings, such as isolation level and access mode, and adds corresponding unit tests to verify this functionality.

**Driver enhancements:**

* Modified the `beginTransaction` method in `BunPostgresDriver` to accept a `TransactionSettings` parameter, allowing transactions to be started with specific isolation levels and access modes. The SQL statement is dynamically constructed based on these settings.
* Imported the `TransactionSettings` type from `kysely` to support the new method signature.

**Testing improvements:**

* Updated existing unit tests to call `beginTransaction` with the new settings parameter.
* Added a new unit test to verify that transactions are started with the correct SQL when both isolation level and access mode are specified.### Summary

Describe the change and why it’s needed.

### Checklist

- [ ] Linted (`bun run lint`)
- [ ] Typechecked (`bun run typecheck`)
- [ ] Tests pass (`bun test`)
- [ ] Added/updated tests (if behavior changed)
