### PR TITLE
Fix malformed array literal when inserting PostgreSQL array fields

### DIFF
--- a/src/driver.ts
+++ b/src/driver.ts
@@ -271,11 +271,18 @@ class BunPostgresConnection implements DatabaseConnection {
 	async executeQuery<O>(compiledQuery: CompiledQuery): Promise<QueryResult<O>> {
 		const { sql, parameters } = compiledQuery;
 
+		// Transform array parameters to use sql.array() for PostgreSQL compatibility.
+		// Without this, passing a JavaScript array directly to unsafe() results in
+		// a "malformed array literal" error from PostgreSQL.
+		const transformedParams = parameters.map((param) =>
+			Array.isArray(param) ? this.#client.array(param) : param,
+		);
+
 		// Use unsafe to execute the compiled SQL with $1-style bindings
 		// Bun SQL returns an array with additional properties (count, command)
 		const result = (await this.#client.unsafe(
 			sql,
-			parameters as unknown[],
+			transformedParams as unknown[],
 		)) as BunSqlResult<O>;
 
 		// Extract the command type and count from Bun's result

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -274,10 +274,23 @@ class BunPostgresConnection implements DatabaseConnection {
 		// Transform array parameters to use sql.array() for PostgreSQL compatibility.
 		// Without this, passing a JavaScript array directly to unsafe() results in
 		// a "malformed array literal" error from PostgreSQL.
-		const transformedParams = parameters.map((param) =>
-			Array.isArray(param) ? this.#client.array(param) : param,
-		);
+		const hasArrayParams = parameters.some(Array.isArray);
 
+		// Feature-detect SQL#array to provide a clear error on unsupported Bun versions.
+		if (hasArrayParams && typeof (this.#client as any).array !== "function") {
+			throw new Error(
+				"Bun SQL#array is not available on this Bun version. " +
+					"Encoding array parameters requires a Bun release that supports SQL#array. " +
+					"Please upgrade Bun or avoid passing array parameters to queries.",
+			);
+		}
+
+		const sqlClient: any = this.#client;
+		const transformedParams = hasArrayParams
+			? parameters.map((param) =>
+					Array.isArray(param) ? sqlClient.array(param) : param,
+				)
+			: parameters;
 		// Use unsafe to execute the compiled SQL with $1-style bindings
 		// Bun SQL returns an array with additional properties (count, command)
 		const result = (await this.#client.unsafe(

--- a/test/bun-postgres-driver.unit.test.ts
+++ b/test/bun-postgres-driver.unit.test.ts
@@ -91,7 +91,7 @@ describe("BunPostgresDriver (unit)", () => {
 
 		// The value passed to unsafe() should be the wrapped array parameter, not the raw array
 		const [, firstParams] = unsafe.mock.calls[0] as [string, unknown[]];
-		expect(Array.isArray(firstParams?.[0])).toBe(false);
+		expect(firstParams[0]).toBe(array.mock.results[0].value);
 
 		await driver.releaseConnection(conn);
 	});

--- a/test/bun-postgres-driver.unit.test.ts
+++ b/test/bun-postgres-driver.unit.test.ts
@@ -10,10 +10,17 @@ describe("BunPostgresDriver (unit)", () => {
 			return [{ sql, params }];
 		});
 
+		const array = mock((values: unknown[]) => ({ values, arrayType: "JSON" }));
+
 		const release = mock(() => {});
-		const reserved: { unsafe: typeof unsafe; release: () => void } = {
+		const reserved: {
+			unsafe: typeof unsafe;
+			release: () => void;
+			array: typeof array;
+		} = {
 			unsafe,
 			release,
+			array,
 		};
 
 		const close = mock(async () => {});
@@ -26,7 +33,7 @@ describe("BunPostgresDriver (unit)", () => {
 			reserve,
 			close,
 		};
-		return { client, reserved, unsafe, release, reserve, close };
+		return { client, reserved, unsafe, array, release, reserve, close };
 	}
 
 	// Helper to create a result array with command and count properties (mimics Bun.SQL result)
@@ -63,6 +70,47 @@ describe("BunPostgresDriver (unit)", () => {
 		expect(firstSql).toBe(cq.sql);
 		expect(firstParams).toEqual([...cq.parameters]);
 		expect(result.rows.length).toBe(1);
+
+		await driver.releaseConnection(conn);
+	});
+
+	test("executeQuery wraps array parameters with sql.array()", async () => {
+		const { client, unsafe, array } = createStubClient();
+		const driver = new BunPostgresDriver({ client: client as unknown as SQL });
+		await driver.init();
+		const conn = await driver.acquireConnection();
+
+		const cq = CompiledQuery.raw("insert into t (tags) values ($1)", [
+			["a", "b", "c"],
+		]);
+		await conn.executeQuery(cq);
+
+		// array() should have been called once with the array parameter
+		expect(array).toHaveBeenCalledTimes(1);
+		expect(array.mock.calls[0]).toEqual([["a", "b", "c"]]);
+
+		// The value passed to unsafe() should be the wrapped array parameter, not the raw array
+		const [, firstParams] = unsafe.mock.calls[0] as [string, unknown[]];
+		expect(Array.isArray(firstParams?.[0])).toBe(false);
+
+		await driver.releaseConnection(conn);
+	});
+
+	test("executeQuery does not wrap non-array parameters with sql.array()", async () => {
+		const { client, unsafe, array } = createStubClient();
+		const driver = new BunPostgresDriver({ client: client as unknown as SQL });
+		await driver.init();
+		const conn = await driver.acquireConnection();
+
+		const cq = CompiledQuery.raw("select $1::int as x", [123]);
+		await conn.executeQuery(cq);
+
+		// array() should NOT have been called for scalar parameters
+		expect(array).not.toHaveBeenCalled();
+
+		// The value passed to unsafe() should be the original scalar
+		const [, firstParams] = unsafe.mock.calls[0] as [string, unknown[]];
+		expect(firstParams).toEqual([123]);
 
 		await driver.releaseConnection(conn);
 	});


### PR DESCRIPTION
### Summary

Fix https://github.com/lacion/kysely-bun-sql/issues/33

Bun's `unsafe()` does not automatically encode JavaScript arrays as PostgreSQL array literals — passing them raw causes `ERROR: malformed array literal`. Array parameters must be wrapped with `sql.array()` before being passed to `unsafe()`.

**`src/driver.ts`**
- In `BunPostgresConnection.executeQuery()`, map over `parameters` and wrap any `Array.isArray` value with `this.#client.array()` before calling `unsafe()`

**`test/bun-postgres-driver.unit.test.ts`**
- Add `array` mock to `createStubClient()`
- Add tests asserting array params are wrapped and scalar params are not

```ts
// Before: arrays passed raw → "malformed array literal"
await this.#client.unsafe(sql, parameters as unknown[]);

// After: arrays wrapped as SQLArrayParameter
const transformedParams = parameters.map((param) =>
  Array.isArray(param) ? this.#client.array(param) : param,
);
await this.#client.unsafe(sql, transformedParams as unknown[]);
```

### Checklist

- [x] Linted (`bun run lint`)
- [x] Typechecked (`bun run typecheck`)
- [x] Tests pass (`bun test`)
- [x] Added/updated tests (if behavior changed)

### Notes

Requires Bun ≥ version that ships `sql.array()` support (see [oven-sh/bun#22946](https://github.com/oven-sh/bun/pull/22946)).
